### PR TITLE
packaging: Do not force pulseaudio version in file paths

### DIFF
--- a/rpm/pulseaudio-modules-droid-glue.spec
+++ b/rpm/pulseaudio-modules-droid-glue.spec
@@ -43,6 +43,5 @@ fi
 %meson_install
 
 %files
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/*.so
+%{_libdir}/pulse-*/modules/*.so
 %license COPYING


### PR DESCRIPTION
Remove not needed defattr from spec.

[packaging] Do not force pulseaudio version in file paths. JB#60996